### PR TITLE
add additional header-handling

### DIFF
--- a/base/index.php.dist
+++ b/base/index.php.dist
@@ -2,6 +2,14 @@
 
 require_once __DIR__ . '/vendor/autoload.php';
 
+// set cache lifetime in seconds
+$cacheLifetime = 3600;
+
+// set additional custom headers HEADER_KEY => HEADER_VALUE
+$additionalHeaders = [
+
+];
+
 $cacheDriver = new \Symfony\Component\Cache\Adapter\FilesystemAdapter();
 
 $cacheIdGenerator = new \Queo\Typo3\SoftwareCache\Cache\CombinedIdGenerator([
@@ -13,12 +21,29 @@ $logger = new \Psr\Log\NullLogger;
 $proxy   = new \Queo\Typo3\SoftwareCache\Proxy\Proxy($cacheDriver, $cacheIdGenerator, $logger);
 $request = \Symfony\Component\HttpFoundation\Request::createFromGlobals();
 
+// override default cache lifetime
+$proxy->setCacheLifetime(300);
+
 $proxy->addRequestRules([
     new \Queo\Typo3\SoftwareCache\Request\Rule\HttpMethodRule('GET')
 ]);
 $proxy->handleRequest($request);
 
 require $_SERVER['DOCUMENT_ROOT'] . '/typo3.php';
+
+/**
+ * HANDLE CONFIGURED TYPO3 PAGE HEADERS
+ */
+
+// get header-data of typo3 page config
+$additionalTypo3Headers = [];
+foreach ($GLOBALS['TSFE']->config['config']['additionalHeaders.'] as $headerItem) {
+    $headerStringSegments = explode(':', $headerItem['header']);
+    $additionalTypo3Headers[trim($headerStringSegments[0])] = trim($headerStringSegments[1]);
+}
+
+// set additional headers
+$proxy->addAdditionalHeaders(array_merge($additionalTypo3Headers, $additionalHeaders));
 
 $response = new \Symfony\Component\HttpFoundation\Response($GLOBALS['TSFE']->content);
 

--- a/src/Proxy/Proxy.php
+++ b/src/Proxy/Proxy.php
@@ -15,7 +15,7 @@ class Proxy
     /**
      * @var int default cache lifetime in seconds
      */
-    protected const DEFAULT_CACHE_LIFETIME = 900;
+    const DEFAULT_CACHE_LIFETIME = 900;
 
     /**
      * @var CacheItemPoolInterface

--- a/src/Tests/Proxy/ProxyTest.php
+++ b/src/Tests/Proxy/ProxyTest.php
@@ -68,4 +68,30 @@ class ProxyTest extends TestCase
 
         $this->assertEquals('Hello', $output);
     }
+
+    public function testGetDefaultCacheLifetime()
+    {
+        $this->assertInternalType("int", $this->proxy->getCacheLifetime());
+    }
+
+    public function testCustomCacheLifetimeHandling()
+    {
+        $customCacheLifetime = 9999;
+        $this->proxy->setCacheLifetime($customCacheLifetime);
+        $this->assertEquals($customCacheLifetime, $this->proxy->getCacheLifetime());
+    }
+
+    public function testBuildHeaderData()
+    {
+        $headerToTest = ['testHeader' => 'testValue'];
+        $this->proxy->addAdditionalHeaders($headerToTest);
+
+        $response = Response::create('Hello');
+        /** @var Response $cacheItem */
+        $cacheItem = $this->proxy->buildHeaderData($response);
+
+        foreach($headerToTest as $headerkey => $headerValue) {
+            $this->assertEquals($headerToTest[$headerkey], $cacheItem->headers->get($headerkey) );
+        }
+    }
 }


### PR DESCRIPTION
index.php.dist
* add variables to set custom cache-lifetime and custom headers
* add typo3-configured page-headers
Proxy
* add properties for default- and additionalHeaders and constant for default cache-lifetime
* set headers via method (merge default and additional headers)
* set expireAfter to cache-lifetime
Tests\Proxy
* add tests for header-handling